### PR TITLE
Add option to always run script (even for suppressed notifications)

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -115,6 +115,10 @@ print version information.
 
 use alternative config file.
 
+=item B<-always_run_script>
+
+Always run rule-defined scripts, even if the notification is suppressed with format = "".
+
 =back
 
 =head1 FORMAT

--- a/notification.c
+++ b/notification.c
@@ -462,6 +462,9 @@ int notification_init(notification * n, int id)
 
         if (strlen(n->msg) == 0) {
                 notification_close(n, 2);
+                if (settings.always_run_script) {
+                        notification_run_script(n);
+                }
                 printf("skipping notification: %s %s\n", n->body, n->summary);
         } else {
                 g_queue_insert_sorted(queue, n, notification_cmp_data, NULL);

--- a/settings.c
+++ b/settings.c
@@ -322,6 +322,10 @@ void load_settings(char *cmdline_config_path)
             cmdline_get_bool("-print", false,
                              "Print notifications to cmdline (DEBUG)");
 
+        settings.always_run_script =
+            option_get_bool("global", "always_run_script", "-always_run_script", true,
+                              "Always run rule-defined scripts, even if the notification is suppressed with format = \"\".");
+
         /* push hardcoded default rules into rules list */
         for (int i = 0; i < LENGTH(default_rules); i++) {
                 rules = g_slist_insert(rules, &(default_rules[i]), -1);

--- a/settings.h
+++ b/settings.h
@@ -51,6 +51,7 @@ typedef struct _settings {
         enum icon_position_t icon_position;
         char *icon_folders;
         enum follow_mode f_mode;
+        bool always_run_script;
         keyboard_shortcut close_ks;
         keyboard_shortcut close_all_ks;
         keyboard_shortcut history_ks;


### PR DESCRIPTION
Adds option always_run_script.
If set to true, scripts defined by a rule will always be executed, even if the format is set to "" to suppress the notification.

Niche, but useful when a user wants an action triggered by an application's notification but doesn't want the actual notification (see issue 212).

Please excuse my being bad at git.