### PR TITLE
Fix category rule matching

### DIFF
--- a/notification.c
+++ b/notification.c
@@ -153,6 +153,9 @@ void notification_free(notification * n)
         free(n->summary);
         free(n->body);
         free(n->icon);
+        if (n->category && strcmp(n->category, "")) {
+                free(n->category);
+        }
         free(n->msg);
         free(n->dbus_client);
 
@@ -335,6 +338,10 @@ int notification_init(notification * n, int id)
 
         n->format = settings.format;
 
+        if (n->category == NULL) {
+                n->category = "";
+        }
+
         rule_apply_all(n);
 
         n->urls = notification_extract_markup_urls(&(n->body));
@@ -448,10 +455,6 @@ int notification_init(notification * n, int id)
         else if (strlen(n->icon) <= 0) {
                 free(n->icon);
                 n->icon = strdup(settings.icons[n->urgency]);
-        }
-
-        if (n->category == NULL) {
-                n->category = "";
         }
 
         n->timestamp = time(NULL);

--- a/settings.c
+++ b/settings.c
@@ -363,6 +363,7 @@ void load_settings(char *cmdline_config_path)
                 r->summary = ini_get_string(cur_section, "summary", r->summary);
                 r->body = ini_get_string(cur_section, "body", r->body);
                 r->icon = ini_get_string(cur_section, "icon", r->icon);
+                r->category = ini_get_string(cur_section, "category", r->category);
                 r->timeout = ini_get_int(cur_section, "timeout", r->timeout);
                 r->allow_markup = ini_get_bool(cur_section, "allow_markup", r->allow_markup);
                 r->plain_text = ini_get_bool(cur_section, "plain_text", r->plain_text);


### PR DESCRIPTION
Bug: the existance of a rule section containing a category match
resulted in *all* notifications matching this particular rule.

Solution: Properly extract the category string from the rule section. If
the rule section did not have a category matcher, make sure we at least
have the empty string before doing rule_apply_all() (fnmatch() borks on
NULL!)